### PR TITLE
Raise error if zip or unzip fail

### DIFF
--- a/src/02_wad.rb
+++ b/src/02_wad.rb
@@ -127,14 +127,14 @@ class Wad
   def zip
     log "Creating Wad with tar (#{bzip_filename})"
     system("cd #{project_root} && tar -cjf #{bzip_filename} #{bundler_path}")
-    raise "Failed to create Wad" if not $?.success
+    raise "Failed to create Wad" if not $?.success?
   end
 
 
   def unzip
     log "Unpacking Wad with tar (#{bzip_filename})"
     system("cd #{project_root} && tar -xjf #{bzip_filename}")
-    raise "Failed to unpack Wad" if not $?.success
+    raise "Failed to unpack Wad" if not $?.success?
   end
 
   def put

--- a/src/02_wad.rb
+++ b/src/02_wad.rb
@@ -127,12 +127,14 @@ class Wad
   def zip
     log "Creating Wad with tar (#{bzip_filename})"
     system("cd #{project_root} && tar -cjf #{bzip_filename} #{bundler_path}")
+    raise "Failed to create Wad" if not $?.success
   end
 
 
   def unzip
     log "Unpacking Wad with tar (#{bzip_filename})"
     system("cd #{project_root} && tar -xjf #{bzip_filename}")
+    raise "Failed to unpack Wad" if not $?.success
   end
 
   def put


### PR DESCRIPTION
I ran into a case where it seemed to fetch the tarball from S3 correctly but it failed to extract:

```
$ travis_retry ~/wad
[wad] Trying to fetch Wad from S3
[wad] Unpacking Wad with tar (/home/travis/build/.../fc4466782de707bd80dff01f2fc59f7a.tar.bz2)
bzip2: Compressed file ends unexpectedly;
    perhaps it is corrupted?  *Possible* reason follows.
bzip2: Inappropriate ioctl for device
    Input file = (stdin), output file = (stdout)
It is possible that the compressed file(s) have become corrupted.
You can use the -tvv option to test integrity of such files.
You can use the `bzip2recover' program to attempt to recover
data from undamaged sections of corrupted files.
tar: Unexpected EOF in archive
tar: Unexpected EOF in archive
tar: Error is not recoverable: exiting now
[wad] Installing bundle
... 
```
